### PR TITLE
Upgrade check

### DIFF
--- a/components/bio-formats/utils/bfUpgradeCheck.m
+++ b/components/bio-formats/utils/bfUpgradeCheck.m
@@ -35,8 +35,9 @@ fprintf('*** A new stable version of Bio-Formats is available ***\n');
 % If appliable, download new version of Bioformats
 if ip.Results.autoDownload
     fprintf('*** Downloading... ***');
-    path = fullfile(fileparts(mfilename('fullpath')), 'loci_tools.jar');
-    buildName=[upper(ip.Results.version) '_BUILD'];
-    upgrader.install(loci.formats.UpgradeChecker.(buildName), path);
+    downloadPath = fullfile(fileparts(mfilename('fullpath')), 'loci_tools.jar');
+    jarPath=char(loci.formats.UpgradeChecker.([upper(ip.Results.version) '_BUILD']));
+    jarName =char(loci.formats.UpgradeChecker.TOOLS);
+    upgrader.install([jarPath jarName], downloadPath);
     fprintf('*** Upgrade will be finished when MATLAB is restarted ***\n');
 end

--- a/components/scifio/src/loci/formats/UpgradeChecker.java
+++ b/components/scifio/src/loci/formats/UpgradeChecker.java
@@ -64,13 +64,13 @@ public class UpgradeChecker {
    * Location of the JAR artifacts for Bio-Formats' trunk build.
    */
   public static final String TRUNK_BUILD =
-    CI_SERVER + "/job/BIOFORMATS-trunk/artifact/artifacts/";
+    CI_SERVER + "/job/BIOFORMATS-trunk/lastSuccessfulBuild/artifact/artifacts/";
 
   /**
    * Location of the JAR artifacts for Bio-Formats' daily build.
    */
   public static final String DAILY_BUILD =
-    CI_SERVER + "/job/BIOFORMATS-daily/artifact/artifacts/";
+    CI_SERVER + "/job/BIOFORMATS-daily/lastSuccessfulBuild/artifact/artifacts/";
 
   /**
    * Location of the JAR artifacts for the stable releases.


### PR DESCRIPTION
This PR fixes two bugs for the upgrade checker. 
The first change is specific to the bfUpgradeCheck function (jar name appending). The second change changes to path of the trunk/daily build URL.

@melissalinkert, can you double check the daily and trunk build install also works using UpgradeCheck?
