### PR TITLE
Improve 3D volume function

### DIFF
--- a/components/bio-formats/matlab/bfOpen3DVolume.m
+++ b/components/bio-formats/matlab/bfOpen3DVolume.m
@@ -15,14 +15,14 @@ function volume = bfOpen3DVolume(filename)
 %   volume - 3D array containing all images in the file.
 
 % Prompt for a file if not input
-if nargin==0 || exist(filename,'file') == 0
-  [file,path] = uigetfile(bfGetFileExtensions, 'Choose a file to open');
+if nargin == 0 || exist(filename, 'file') == 0
+  [file, path] = uigetfile(bfGetFileExtensions, 'Choose a file to open');
   filename = [path file];
-  if isequal(path,0) || isequal(file,0), return; end
+  if isequal(path, 0) || isequal(file, 0), return; end
 end
 
 volume = bfopen(filename);
-vaux{1} = cat(3,volume{1}{:,1});
+vaux{1} = cat(3, volume{1}{:,1});
 vaux{2} = filename;
 volume{1} = vaux;
 end

--- a/components/bio-formats/matlab/bfOpen3DVolume.m
+++ b/components/bio-formats/matlab/bfOpen3DVolume.m
@@ -14,6 +14,12 @@ function volume = bfOpen3DVolume(filename)
 %
 %   volume - 3D array containing all images in the file.
 
+% Prompt for a file if not input
+if nargin==0 || exist(filename,'file') == 0
+  [file,path] = uigetfile(bfGetFileExtensions, 'Choose a file to open');
+  filename = [path file];
+  if isequal(path,0) || isequal(file,0), return; end
+end
 
 volume = bfopen(filename);
 vaux{1} = cat(3,volume{1}{:,1});

--- a/components/bio-formats/matlab/bfOpen3DVolume.m
+++ b/components/bio-formats/matlab/bfOpen3DVolume.m
@@ -14,8 +14,9 @@ function volume = bfOpen3DVolume(filename)
 %
 %   volume - 3D array containing all images in the file.
 
-    volume = bfopen(filename);
-    vaux{1} = cat(3,volume{1}{:,1});
-    vaux{2} = filename;
-    volume{1} = vaux;
+
+volume = bfopen(filename);
+vaux{1} = cat(3,volume{1}{:,1});
+vaux{2} = filename;
+volume{1} = vaux;
 end

--- a/components/bio-formats/matlab/bfOpen3DVolume.m
+++ b/components/bio-formats/matlab/bfOpen3DVolume.m
@@ -15,10 +15,7 @@ function volume = bfOpen3DVolume(filename)
 %   volume - 3D array containing all images in the file.
 
     volume = bfopen(filename);
-    vaux{1} = zeros([size(volume{1}, 1), size(volume{1}{1})]);
-    for k = 1:size(vaux{1}, 1)
-        vaux{1}(:,:,k) = volume{1}{k};
-    end
+    vaux{1} = cat(3,volume{1}{:,1});
     vaux{2} = filename;
     volume{1} = vaux;
 end


### PR DESCRIPTION
Fix bugs in PR #61.
- Use the cat(dim,c{:}) function to slightly improve speed (see [test script](git://gist.github.com/2575993.git))
- Add support for optional filename argument
