### PR TITLE
9601

### DIFF
--- a/components/bio-formats/build.xml
+++ b/components/bio-formats/build.xml
@@ -22,7 +22,7 @@ Type "ant -p" for a list of targets.
       <classpath>
         <pathelement location="${test-classes.dir}"/>
         <pathelement location="${classes.dir}"/>
-        <pathelement path="${component.classpath}"/>
+        <pathelement path="${component.runtime-cp}"/>
       </classpath>
       <xmlfileset file="${build.dir}/testng.xml"/>
       <jvmarg value="-mx${testng.memory}"/>
@@ -83,7 +83,7 @@ Type "ant -p" for a list of targets.
       <classpath>
         <pathelement location="${test-classes.dir}"/>
         <pathelement location="${classes.dir}"/>
-        <pathelement path="${component.classpath}"/>
+        <pathelement path="${component.runtime-cp}"/>
       </classpath>
       <classfileset file="${test-classes.dir}/loci/formats/utests/MetadataConfigurableTest.class"/>
       <sysproperty key="testng.filename" value="${testng.filename}"/>

--- a/components/loci-plugins/build.properties
+++ b/components/loci-plugins/build.properties
@@ -16,7 +16,8 @@ component.classpath      = ${artifact.dir}/bio-formats.jar:\
                            ${lib.dir}/forms-1.3.0.jar:\
                            ${lib.dir}/ij.jar:\
                            ${lib.dir}/junit-4.8.2.jar:\
-                           ${lib.dir}/log4j-1.2.15.jar
+                           ${lib.dir}/log4j-1.2.15.jar:\
+                           ${lib.dir}/slf4j-api-1.5.10.jar
 component.java-version   = 1.5
 component.deprecation    = true
 
@@ -26,6 +27,7 @@ component.resources-text = plugins.config \
                            loci/plugins/in/*.txt
 
 component.main-class     = loci.plugins.About
-component.runtime-cp     = ${component.classpath}
+component.runtime-cp     = ${component.classpath}:\
+                           ${lib.dir}/slf4j-log4j12-1.5.10.jar
 
 component.junit          = true

--- a/components/ome-io/build.properties
+++ b/components/ome-io/build.properties
@@ -24,7 +24,8 @@ component.resources-bin  = loci/ome/io/ome-logo.png
 component.resources-text =
 
 component.main-class     = loci.ome.io.OmeroReader
-component.runtime-cp     = ${component.classpath}
+component.runtime-cp     = ${component.classpath}:\
+                           ${lib.dir}/slf4j-log4j12-1.5.10.jar
 
 
 # NB: do not include ${artifact.dir}/bio-formats.jar,
@@ -33,4 +34,5 @@ component.classpath-no-omeio  = ${root.dir}/components/bio-formats/build/classes
                                 ${artifact.dir}/loci-common.jar:\
                                 ${lib.dir}/log4j-1.2.15.jar:\
                                 ${lib.dir}/slf4j-api-1.5.10.jar:\
+                                ${lib.dir}/slf4j-log4j12-1.5.10.jar:\
                                 ${lib.dir}/testng-5.11-jdk15.jar

--- a/components/ome-io/build.xml
+++ b/components/ome-io/build.xml
@@ -20,7 +20,7 @@ Type "ant -p" for a list of targets.
       <classpath>
         <pathelement location="${test-classes.dir}"/>
         <pathelement location="${classes.dir}"/>
-        <pathelement path="${component.classpath}"/>
+        <pathelement path="${component.runtime-cp}"/>
       </classpath>
       <xmlfileset file="${build.dir}/testng.xml"/>
       <jvmarg value="-mx${testng.memory}"/>

--- a/components/scifio/build.properties
+++ b/components/scifio/build.properties
@@ -40,6 +40,7 @@ component.cp.no-xml      = ${artifact.dir}/jai_imageio.jar:\
                            ${lib.dir}/log4j-1.2.15.jar:\
                            ${lib.dir}/netcdf-4.0.jar:\
                            ${lib.dir}/slf4j-api-1.5.10.jar:\
+                           ${lib.dir}/slf4j-log4j12-1.5.10.jar:\
                            ${lib.dir}/testng-5.11-jdk15.jar
 
 # Used by TestNG suite that tests the absence of class from jai_imageio.jar

--- a/components/scifio/build.xml
+++ b/components/scifio/build.xml
@@ -22,7 +22,7 @@ Type "ant -p" for a list of targets.
       <classpath>
         <pathelement location="${test-classes.dir}"/>
         <pathelement location="${classes.dir}"/>
-        <pathelement path="${component.classpath}"/>
+        <pathelement path="${component.runtime-cp}"/>
       </classpath>
       <xmlfileset file="${build.dir}/testng.xml"/>
       <jvmarg value="-Dlurawave.license=XXX"/>

--- a/components/test-suite/build.properties
+++ b/components/test-suite/build.properties
@@ -25,7 +25,8 @@ component.resources-bin  =
 component.resources-text =
 
 component.main-class     =
-component.runtime-cp     = ${component.classpath}
+component.runtime-cp     = ${component.classpath}:\
+                           ${lib.dir}/slf4j-log4j12-1.5.10.jar
 
 testng.memory            = 512m
 reader-test.class        = loci/tests/testng/FormatReaderTestFactory.class

--- a/components/test-suite/build.xml
+++ b/components/test-suite/build.xml
@@ -58,7 +58,7 @@ Type "ant -p" for a list of targets.
       failureProperty="failedTest">
       <classpath>
         <pathelement location="${classes.dir}"/>
-        <pathelement path="${component.classpath}"/>
+        <pathelement path="${component.runtime-cp}"/>
       </classpath>
       <classfileset file="${classes.dir}/loci/tests/testng/CompressDecompressTest.class"/>
     </testng>
@@ -74,7 +74,7 @@ Type "ant -p" for a list of targets.
       failureProperty="failedTest">
       <classpath>
         <pathelement location="${classes.dir}"/>
-        <pathelement path="${component.classpath}"/>
+        <pathelement path="${component.runtime-cp}"/>
       </classpath>
       <classfileset file="${classes.dir}/${writer-test.class}"/>
       <sysproperty key="testng.filename" value="${testng.filename}"/>
@@ -94,7 +94,7 @@ Type "ant -p" for a list of targets.
       failureProperty="failedTest" useDefaultListeners="false">
       <classpath>
         <pathelement location="${classes.dir}"/>
-        <pathelement path="${component.classpath}"/>
+        <pathelement path="${component.runtime-cp}"/>
       </classpath>
       <classfileset file="${classes.dir}/${reader-test.class}"/>
       <sysproperty key="testng.toplevel-config" value="${testng.toplevel-config}"/>
@@ -119,7 +119,7 @@ Type "ant -p" for a list of targets.
       failureProperty="failedTest">
       <classpath>
         <pathelement location="${classes.dir}"/>
-        <pathelement path="${component.classpath}"/>
+        <pathelement path="${component.runtime-cp}"/>
       </classpath>
       <classfileset file="${classes.dir}/${reader-test.class}"/>
       <sysproperty key="testng.toplevel-config" value="${testng.toplevel-config}"/>
@@ -144,7 +144,7 @@ Type "ant -p" for a list of targets.
       failureProperty="failedTest" useDefaultListeners="false">
       <classpath>
         <pathelement location="${classes.dir}"/>
-        <pathelement path="${component.classpath}"/>
+        <pathelement path="${component.runtime-cp}"/>
       </classpath>
       <classfileset file="${classes.dir}/${reader-test.class}"/>
       <sysproperty key="testng.toplevel-config" value="${testng.toplevel-config}"/>
@@ -169,7 +169,7 @@ Type "ant -p" for a list of targets.
       failureProperty="failedTest">
       <classpath>
         <pathelement location="${classes.dir}"/>
-        <pathelement path="${component.classpath}"/>
+        <pathelement path="${component.runtime-cp}"/>
       </classpath>
       <classfileset file="${classes.dir}/${reader-test.class}"/>
       <sysproperty key="testng.toplevel-config" value="${testng.toplevel-config}"/>
@@ -194,7 +194,7 @@ Type "ant -p" for a list of targets.
       failureProperty="failedTest">
       <classpath>
         <pathelement location="${classes.dir}"/>
-        <pathelement path="${component.classpath}"/>
+        <pathelement path="${component.runtime-cp}"/>
       </classpath>
       <classfileset file="${classes.dir}/${reader-test.class}"/>
       <sysproperty key="testng.toplevel-config" value="${testng.toplevel-config}"/>
@@ -219,7 +219,7 @@ Type "ant -p" for a list of targets.
       failureProperty="failedTest">
       <classpath>
         <pathelement location="${classes.dir}"/>
-        <pathelement path="${component.classpath}"/>
+        <pathelement path="${component.runtime-cp}"/>
       </classpath>
       <classfileset file="${classes.dir}/${reader-test.class}"/>
       <sysproperty key="testng.toplevel-config" value="${testng.toplevel-config}"/>
@@ -244,7 +244,7 @@ Type "ant -p" for a list of targets.
       failureProperty="failedTest">
       <classpath>
         <pathelement location="${classes.dir}"/>
-        <pathelement path="${component.classpath}"/>
+        <pathelement path="${component.runtime-cp}"/>
       </classpath>
       <classfileset file="${classes.dir}/${reader-test.class}"/>
       <sysproperty key="testng.toplevel-config" value="${testng.toplevel-config}"/>
@@ -269,7 +269,7 @@ Type "ant -p" for a list of targets.
       failureProperty="failedTest">
       <classpath>
         <pathelement location="${classes.dir}"/>
-        <pathelement path="${component.classpath}"/>
+        <pathelement path="${component.runtime-cp}"/>
       </classpath>
       <classfileset file="${classes.dir}/${reader-test.class}"/>
       <sysproperty key="testng.toplevel-config" value="${testng.toplevel-config}"/>


### PR DESCRIPTION
These changes correct erroneous test classpaths from ${component}.classpath to ${component}.runtime-cp, and add missing logging jars to the component and runtime-cp as necessary.

Fixes #9601.
