### PR TITLE
Add HCS domain when fake image is SPW.

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -773,6 +773,7 @@ public class FakeReader extends FormatReader {
     getOmeXmlMetadata().setRoot(new OMEXMLMetadataRoot(ome));
     // copy populated SPW metadata into destination MetadataStore
     getOmeXmlService().convertMetadata(omeXmlMetadata, store);
+    domains = new String[] {FormatTools.HCS_DOMAIN};
     return ome.sizeOfImageList();
   }
 


### PR DESCRIPTION
This should fix the `SPW: false` message reported by `ImportCandidates.java`.
