### PR TITLE
Handle empty binData tag.

### DIFF
--- a/components/formats-bsd/src/loci/formats/in/OMEXMLReader.java
+++ b/components/formats-bsd/src/loci/formats/in/OMEXMLReader.java
@@ -156,7 +156,8 @@ public class OMEXMLReader extends FormatReader {
     options.interleaved = isInterleaved();
 
     String encoded = in.readString("<");
-    if (encoded.length() == 0) {
+    encoded = encoded.trim();
+    if (encoded.length() == 0 || encoded.equals("<")) {
       LOGGER.debug("No pixel data for plane #{}", no);
       return buf;
     }


### PR DESCRIPTION
This handles the case of empty BinData tag of the form `<Bin:BinData BigEndian="false" Length="32"/>`
